### PR TITLE
1.0.7 — fix flaky browser setup, and make the adb port configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "appium",
     "chrome-dev-tools"
   ],
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "",
   "license": "Apache-2.0",
   "repository": {
@@ -66,6 +66,7 @@
     "chai": "^4.3.6",
     "chrome-remote-interface": "^0.31.3",
     "get-port": "^5.1.1",
+    "node-fetch": "^2.6.7",
     "taiko": "https://github.com/getgauge/taiko.git"
   },
   "peerDependencies": {

--- a/scripts/brave.js
+++ b/scripts/brave.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 import { finishSession } from './browserReady.js';
@@ -19,7 +20,8 @@ const common = {
 };
 
 async function skipWelcomeBrave() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.brave.browser']);
   // Suppress the first-run Welcome walkthrough (honored on emulators/debuggable builds;
   // harmless no-op elsewhere, where the UI walkthrough below still handles it)
@@ -31,6 +33,7 @@ async function skipWelcomeBrave() {
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": "com.brave.browser",
     "appium:appActivity": "com.google.android.apps.chrome.Main",

--- a/scripts/brave.js
+++ b/scripts/brave.js
@@ -23,12 +23,17 @@ async function skipWelcomeBrave() {
   const adbPort = resolveAdbPort();
   const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.brave.browser']);
-  // Suppress the first-run Welcome walkthrough (honored on emulators/debuggable builds;
-  // harmless no-op elsewhere, where the UI walkthrough below still handles it)
-  await adb.adbExec([
-    'shell',
-    "echo '_ --disable-fre --no-first-run' > /data/local/tmp/chrome-command-line",
-  ]);
+  // Optional: suppress Chromium's first-run experience. Off by default because
+  // /data/local/tmp/chrome-command-line is shared with Chrome and chromedriver,
+  // which writes its own chromeOptions.args there — clobbering it would change
+  // an unrelated Chrome session on the same device. Set CDP_SUPPRESS_FIRST_RUN=1
+  // to opt in; without it the readiness pass dismisses onboarding instead.
+  if (process.env.CDP_SUPPRESS_FIRST_RUN === '1') {
+    await adb.adbExec([
+      'shell',
+      "echo '_ --disable-fre --no-first-run' > /data/local/tmp/chrome-command-line",
+    ]);
+  }
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
@@ -120,7 +125,7 @@ async function skipWelcomeBrave() {
   } catch (error) {
     log.info(`walkthrough did not complete (${error.message}) — checking readiness anyway`);
   } finally {
-    await finishSession(driver, { adb, pkg: brave.pkg, socket: 'chrome_devtools_remote' });
+    await finishSession(driver, { adb, pkg: brave.pkg, component: `${brave.pkg}/${brave.activity}`, socket: 'chrome_devtools_remote' });
   }
 }
 

--- a/scripts/brave.js
+++ b/scripts/brave.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,7 +19,8 @@ const common = {
 };
 
 async function skipWelcomeBrave() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.brave.browser']);
   // Suppress the first-run Welcome walkthrough (honored on emulators/debuggable builds;
   // harmless no-op elsewhere, where the UI walkthrough below still handles it)
@@ -30,6 +32,7 @@ async function skipWelcomeBrave() {
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": "com.brave.browser",
     "appium:appActivity": "com.google.android.apps.chrome.Main",

--- a/scripts/brave.js
+++ b/scripts/brave.js
@@ -4,6 +4,7 @@ import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
+import { finishSession } from './browserReady.js';
 
 const START_APP_WAIT_DURATION = 60000;
 
@@ -113,8 +114,10 @@ async function skipWelcomeBrave() {
       );
       await driver.click(continueButton.ELEMENT);
     }
+  } catch (error) {
+    log.info(`walkthrough did not complete (${error.message}) — checking readiness anyway`);
   } finally {
-    await driver.deleteSession();
+    await finishSession(driver, { adb, pkg: brave.pkg, socket: 'chrome_devtools_remote' });
   }
 }
 

--- a/scripts/browserReady.js
+++ b/scripts/browserReady.js
@@ -1,0 +1,154 @@
+import log from '../src/logger.js';
+
+/**
+ * Shared readiness helper for the skip-welcome-* scripts.
+ *
+ * The scripts clear the browser profile and then click through first-run
+ * onboarding. That choreography is inherently racy: dialog order and content
+ * vary per launch, some stages are conditional, and an Android system dialog
+ * (e.g. "System UI isn't responding") can cover the screen entirely. When it
+ * goes wrong the browser never opens its devtools socket and session creation
+ * fails later with "socket hang up" or "Debug list is empty or invalid".
+ *
+ * Instead of requiring a fixed sequence, converge on the end state the driver
+ * actually needs: the browser's own devtools socket, with onboarding gone and a
+ * page open. Dismiss whatever happens to be on screen, relaunch when stuck, and
+ * report honestly if it never becomes ready.
+ */
+
+const ONBOARDING_ACTIVITY = /Welcome|FirstRun|firstrun|Onboarding|HelpIntro/i;
+
+// Safe to click on first-run and system dialogs, in priority order. "Wait" is
+// first so an ANR dialog is cleared before anything underneath it is touched.
+const COMMON_SELECTORS = [
+  '//android.widget.Button[@text="Wait"]',
+  '//android.widget.Button[@text="OK"]',
+  '//android.widget.Button[@text="Continue"]',
+  '//android.widget.Button[@text="Next"]',
+  '//android.widget.Button[@text="Skip"]',
+  '//android.widget.Button[@text="Not now"]',
+  '//android.widget.Button[@text="Allow"]',
+];
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function socketPresent(adb, socket, pkg, pidScoped) {
+  const unix = String(await adb.adbExec(['shell', 'cat', '/proc/net/unix']));
+  if (!pidScoped) {
+    return unix.includes(socket);
+  }
+  // WebView-based browsers expose webview_devtools_remote_<pid>; the bare prefix
+  // also matches other apps' WebViews, so scope it to this package's pid.
+  const pid = String(await adb.adbExec(['shell', 'pidof', pkg])).trim().split(/\s+/)[0];
+  return Boolean(pid) && unix.includes(`${socket}_${pid}`);
+}
+
+async function currentActivity(driver) {
+  try {
+    return String(await driver.getCurrentActivity());
+  } catch (e) {
+    return '';
+  }
+}
+
+async function openPage(adb, pkg, url) {
+  await adb.adbExec(['shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url, pkg]);
+}
+
+/**
+ * @param {object} opts
+ * @param {object} opts.driver     UiAutomator2 driver used for the walkthrough
+ * @param {object} opts.adb        appium-adb instance
+ * @param {string} opts.pkg        browser package name
+ * @param {string} opts.socket     devtools socket name (see DEVTOOLS_SOCKET_MAP)
+ * @param {boolean} [opts.pidScoped]  socket name is suffixed with the pid (WebView apps)
+ * @param {string[]} [opts.selectors] browser-specific selectors, tried before the common ones
+ * @param {string} [opts.url]      page to open once the socket is up
+ * @param {number} [opts.attempts]
+ * @returns {Promise<boolean>} whether the browser became ready
+ */
+export async function ensureBrowserReady(opts) {
+  const {
+    driver, adb, pkg, socket,
+    pidScoped = false,
+    selectors = [],
+    url = 'https://www.appium.io',
+    attempts = 12,
+    intervalMs = 2500,
+  } = opts;
+  const candidates = [...selectors, ...COMMON_SELECTORS];
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      // The process (and its socket) can exist while onboarding is still on
+      // screen; with no tab open /json/list is empty, which is the "Debug list
+      // is empty" failure. Require both, then open a page.
+      const activity = await currentActivity(driver);
+      if (ONBOARDING_ACTIVITY.test(activity)) {
+        log.info(`ensureBrowserReady: still on onboarding (${activity})`);
+      } else if (await socketPresent(adb, socket, pkg, pidScoped)) {
+        await openPage(adb, pkg, url);
+        await sleep(4000);
+        return true;
+      }
+    } catch (e) {
+      // fall through to the dismissal pass
+    }
+
+    let clicked = null;
+    for (const selector of candidates) {
+      try {
+        const element = await driver.findElement('xpath', selector);
+        await driver.click(element.ELEMENT);
+        clicked = selector;
+        break;
+      } catch (e) {
+        // selector not present — try the next one
+      }
+    }
+
+    if (clicked) {
+      log.info(`ensureBrowserReady: dismissed ${clicked}`);
+    } else if (attempt % 3 === 2) {
+      log.info(`ensureBrowserReady: nothing to dismiss, relaunching ${pkg}`);
+      try {
+        await openPage(adb, pkg, url);
+      } catch (e) {
+        // browser may still be starting
+      }
+    }
+    await sleep(intervalMs);
+  }
+  return false;
+}
+
+/**
+ * Click an element without letting a stale/handled element abort the rest of the
+ * walkthrough — the screen often changes under it.
+ */
+export async function clickSafely(driver, element) {
+  try {
+    await driver.click(element.ELEMENT);
+  } catch (error) {
+    log.info(`click failed, continuing: ${error.message}`);
+  }
+}
+
+/**
+ * Close out a skip-welcome script: make the browser ready, always release the
+ * UiAutomator2 session, and fail loudly if the browser cannot serve a session.
+ * Without the throw, a script that dismissed nothing still exits 0 and the
+ * caller starts a session that is doomed to fail.
+ */
+export async function finishSession(driver, opts) {
+  const ready = await ensureBrowserReady({ driver, ...opts });
+  log.info(`${opts.pkg} devtools ready: ${ready}`);
+  try {
+    await driver.deleteSession();
+  } catch (e) {
+    log.info(`deleteSession failed: ${e.message}`);
+  }
+  if (!ready) {
+    throw new Error(`${opts.pkg}: devtools socket never became available; the browser cannot serve a session`);
+  }
+}

--- a/scripts/browserReady.js
+++ b/scripts/browserReady.js
@@ -42,9 +42,13 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 async function resolveSocket(adb, socket, pkg, pidScoped) {
   const unix = String(await adb.adbExec(['shell', 'cat', '/proc/net/unix']));
   if (!pidScoped) {
+    // Several browsers share a socket name (chrome, brave and edge all use
+    // chrome_devtools_remote). Abstract names are unique per owner, so seeing
+    // the name proves *someone* opened it, not that we did — verifyReady()
+    // confirms ownership before trusting it.
     return unix.includes(socket) ? socket : null;
   }
-  const pid = String(await adb.adbExec(['shell', 'pidof', pkg])).trim().split(/\s+/)[0];
+  const pid = await browserPid(adb, pkg);
   if (!pid) {
     return null;
   }
@@ -53,21 +57,80 @@ async function resolveSocket(adb, socket, pkg, pidScoped) {
 }
 
 /**
- * Ask /json/list exactly as the driver will. The socket can be up while the
- * browser has no debuggable page — that is the "Debug list is empty or invalid"
- * failure — so an open page is the only meaningful proof of readiness.
+ * First pid of the package. pidof returns a space-separated list when the app
+ * has several processes, and only the first is the browser process whose
+ * WebView socket we want.
  */
-async function hasDebuggablePage(adb, socketName) {
+export async function browserPid(adb, pkg) {
+  const output = String(await adb.adbExec(['shell', 'pidof', pkg])).trim();
+  return output ? output.split(/\s+/)[0] : null;
+}
+
+async function getJson(port, path) {
+  const response = await fetch(`http://localhost:${port}${path}`);
+  return response.json();
+}
+
+/**
+ * Confirm the devtools endpoint belongs to the browser we are setting up.
+ * Chrome for Android reports the owning package in /json/version, which
+ * disambiguates the shared chrome_devtools_remote name.
+ */
+async function ownedByPackage(port, pkg) {
+  try {
+    const version = await getJson(port, '/json/version');
+    const owner = version['Android-Package'];
+    if (!owner) {
+      return true; // endpoint does not report an owner; nothing to contradict
+    }
+    if (owner !== pkg) {
+      log.info(`ensureBrowserReady: devtools socket belongs to ${owner}, not ${pkg}`);
+      return false;
+    }
+  } catch (e) {
+    log.info(`ensureBrowserReady: /json/version check failed: ${e.message}`);
+  }
+  return true;
+}
+
+/**
+ * Ask /json/list the way the driver does. The socket can be up while the
+ * browser has no page — that is the "Debug list is empty or invalid" failure —
+ * so an attachable *page* is the only meaningful proof of readiness. Workers
+ * also carry a webSocketDebuggerUrl and must not be mistaken for one.
+ */
+async function verifyReady(adb, socketName, pkg, timeoutMs = 5000, intervalMs = 500) {
   const port = await getPort();
   try {
     await adb.adbExec(['forward', `tcp:${port}`, `localabstract:${socketName}`]);
-    const response = await fetch(`http://localhost:${port}/json/list`);
-    const targets = await response.json();
-    const pages = (Array.isArray(targets) ? targets : []).filter((t) => t.webSocketDebuggerUrl);
-    log.info(`ensureBrowserReady: /json/list targets=${Array.isArray(targets) ? targets.length : -1}, with debugger url=${pages.length}`);
-    return pages.length > 0;
+    if (!(await ownedByPackage(port, pkg))) {
+      return false;
+    }
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      let pages = [];
+      let total = -1;
+      try {
+        const targets = await getJson(port, '/json/list');
+        if (Array.isArray(targets)) {
+          total = targets.length;
+          pages = targets.filter((t) => t.type === 'page' && t.webSocketDebuggerUrl);
+        }
+      } catch (e) {
+        log.info(`ensureBrowserReady: /json/list check failed: ${e.message}`);
+      }
+      if (pages.length > 0) {
+        log.info(`ensureBrowserReady: ${pkg} has ${pages.length} page target(s) of ${total}`);
+        return true;
+      }
+      if (Date.now() >= deadline) {
+        log.info(`ensureBrowserReady: ${pkg} has no page target (targets=${total})`);
+        return false;
+      }
+      await sleep(intervalMs);
+    }
   } catch (error) {
-    log.info(`ensureBrowserReady: /json/list check failed: ${error.message}`);
+    log.info(`ensureBrowserReady: readiness check failed: ${error.message}`);
     return false;
   } finally {
     try {
@@ -125,8 +188,10 @@ export async function ensureBrowserReady(opts) {
         const socketName = await resolveSocket(adb, socket, pkg, pidScoped);
         if (socketName) {
           await openPage(adb, pkg, url);
-          await sleep(4000);
-          if (await hasDebuggablePage(adb, socketName)) {
+          // poll rather than sleeping a fixed interval: usually the page is
+          // there within a few hundred ms, and setup should not pay for the
+          // worst case on every session
+          if (await verifyReady(adb, socketName, pkg)) {
             return true;
           }
         }

--- a/scripts/browserReady.js
+++ b/scripts/browserReady.js
@@ -1,3 +1,5 @@
+import fetch from 'node-fetch';
+import getPort from 'get-port';
 import log from '../src/logger.js';
 
 /**
@@ -32,15 +34,48 @@ const COMMON_SELECTORS = [
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function socketPresent(adb, socket, pkg, pidScoped) {
+/**
+ * Resolve the devtools socket name, or null if the browser has not opened it.
+ * WebView-based browsers expose webview_devtools_remote_<pid>; the bare prefix
+ * also matches other apps' WebViews, so scope it to this package's pid.
+ */
+async function resolveSocket(adb, socket, pkg, pidScoped) {
   const unix = String(await adb.adbExec(['shell', 'cat', '/proc/net/unix']));
   if (!pidScoped) {
-    return unix.includes(socket);
+    return unix.includes(socket) ? socket : null;
   }
-  // WebView-based browsers expose webview_devtools_remote_<pid>; the bare prefix
-  // also matches other apps' WebViews, so scope it to this package's pid.
   const pid = String(await adb.adbExec(['shell', 'pidof', pkg])).trim().split(/\s+/)[0];
-  return Boolean(pid) && unix.includes(`${socket}_${pid}`);
+  if (!pid) {
+    return null;
+  }
+  const scoped = `${socket}_${pid}`;
+  return unix.includes(scoped) ? scoped : null;
+}
+
+/**
+ * Ask /json/list exactly as the driver will. The socket can be up while the
+ * browser has no debuggable page — that is the "Debug list is empty or invalid"
+ * failure — so an open page is the only meaningful proof of readiness.
+ */
+async function hasDebuggablePage(adb, socketName) {
+  const port = await getPort();
+  try {
+    await adb.adbExec(['forward', `tcp:${port}`, `localabstract:${socketName}`]);
+    const response = await fetch(`http://localhost:${port}/json/list`);
+    const targets = await response.json();
+    const pages = (Array.isArray(targets) ? targets : []).filter((t) => t.webSocketDebuggerUrl);
+    log.info(`ensureBrowserReady: /json/list targets=${Array.isArray(targets) ? targets.length : -1}, with debugger url=${pages.length}`);
+    return pages.length > 0;
+  } catch (error) {
+    log.info(`ensureBrowserReady: /json/list check failed: ${error.message}`);
+    return false;
+  } finally {
+    try {
+      await adb.adbExec(['forward', '--remove', `tcp:${port}`]);
+    } catch (e) {
+      // the forward may already be gone
+    }
+  }
 }
 
 async function currentActivity(driver) {
@@ -81,15 +116,20 @@ export async function ensureBrowserReady(opts) {
   for (let attempt = 0; attempt < attempts; attempt++) {
     try {
       // The process (and its socket) can exist while onboarding is still on
-      // screen; with no tab open /json/list is empty, which is the "Debug list
-      // is empty" failure. Require both, then open a page.
+      // screen, and even afterwards the browser may hold no debuggable page.
+      // Require onboarding gone, the socket up, and a page the driver can attach to.
       const activity = await currentActivity(driver);
       if (ONBOARDING_ACTIVITY.test(activity)) {
         log.info(`ensureBrowserReady: still on onboarding (${activity})`);
-      } else if (await socketPresent(adb, socket, pkg, pidScoped)) {
-        await openPage(adb, pkg, url);
-        await sleep(4000);
-        return true;
+      } else {
+        const socketName = await resolveSocket(adb, socket, pkg, pidScoped);
+        if (socketName) {
+          await openPage(adb, pkg, url);
+          await sleep(4000);
+          if (await hasDebuggablePage(adb, socketName)) {
+            return true;
+          }
+        }
       }
     } catch (e) {
       // fall through to the dismissal pass

--- a/scripts/browserReady.js
+++ b/scripts/browserReady.js
@@ -35,6 +35,17 @@ const COMMON_SELECTORS = [
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
+ * Targets the driver can actually attach to. Workers also carry a
+ * webSocketDebuggerUrl, so filtering on that field alone would accept a browser
+ * that has no page open — the state this check exists to reject.
+ */
+export function pickPageTargets(targets) {
+  return (Array.isArray(targets) ? targets : []).filter(
+    (t) => t && t.type === 'page' && t.webSocketDebuggerUrl
+  );
+}
+
+/**
  * Resolve the devtools socket name, or null if the browser has not opened it.
  * WebView-based browsers expose webview_devtools_remote_<pid>; the bare prefix
  * also matches other apps' WebViews, so scope it to this package's pid.
@@ -114,7 +125,7 @@ async function verifyReady(adb, socketName, pkg, timeoutMs = 5000, intervalMs = 
         const targets = await getJson(port, '/json/list');
         if (Array.isArray(targets)) {
           total = targets.length;
-          pages = targets.filter((t) => t.type === 'page' && t.webSocketDebuggerUrl);
+          pages = pickPageTargets(targets);
         }
       } catch (e) {
         log.info(`ensureBrowserReady: /json/list check failed: ${e.message}`);

--- a/scripts/browserReady.js
+++ b/scripts/browserReady.js
@@ -160,8 +160,13 @@ async function currentActivity(driver) {
   }
 }
 
-async function openPage(adb, pkg, url) {
-  await adb.adbExec(['shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url, pkg]);
+async function openPage(adb, pkg, component, url) {
+  // target the component: a bare trailing package is not honoured by am, and the
+  // intent would open in whichever browser handles VIEW by default
+  const target = component || pkg;
+  await adb.adbExec([
+    'shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url, '-n', target,
+  ]);
 }
 
 /**
@@ -170,6 +175,7 @@ async function openPage(adb, pkg, url) {
  * @param {object} opts.adb        appium-adb instance
  * @param {string} opts.pkg        browser package name
  * @param {string} opts.socket     devtools socket name (see DEVTOOLS_SOCKET_MAP)
+ * @param {string} [opts.component] pkg/activity used to open a page in this browser
  * @param {boolean} [opts.pidScoped]  socket name is suffixed with the pid (WebView apps)
  * @param {string[]} [opts.selectors] browser-specific selectors, tried before the common ones
  * @param {string} [opts.url]      page to open once the socket is up
@@ -179,6 +185,7 @@ async function openPage(adb, pkg, url) {
 export async function ensureBrowserReady(opts) {
   const {
     driver, adb, pkg, socket,
+    component,
     pidScoped = false,
     selectors = [],
     url = 'https://www.appium.io',
@@ -198,7 +205,7 @@ export async function ensureBrowserReady(opts) {
       } else {
         const socketName = await resolveSocket(adb, socket, pkg, pidScoped);
         if (socketName) {
-          await openPage(adb, pkg, url);
+          await openPage(adb, pkg, component, url);
           // poll rather than sleeping a fixed interval: usually the page is
           // there within a few hundred ms, and setup should not pay for the
           // worst case on every session
@@ -228,7 +235,7 @@ export async function ensureBrowserReady(opts) {
     } else if (attempt % 3 === 2) {
       log.info(`ensureBrowserReady: nothing to dismiss, relaunching ${pkg}`);
       try {
-        await openPage(adb, pkg, url);
+        await openPage(adb, pkg, component, url);
       } catch (e) {
         // browser may still be starting
       }

--- a/scripts/duckduckgo.js
+++ b/scripts/duckduckgo.js
@@ -4,6 +4,7 @@ import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
+import { finishSession } from './browserReady.js';
 
 const START_APP_WAIT_DURATION = 60000;
 
@@ -92,8 +93,24 @@ async function skipWelcomeDuckDuckGo() {
         }
       }
     }
+  } catch (error) {
+    log.info(`walkthrough did not complete (${error.message}) — checking readiness anyway`);
   } finally {
-    await driver.deleteSession();
+    await finishSession(driver, {
+      adb,
+      pkg: duckduckgo.pkg,
+      // WebView app: the socket carries the pid, and the bare prefix would also
+      // match other apps' WebViews
+      socket: 'webview_devtools_remote',
+      pidScoped: true,
+      selectors: [
+        '//*[@resource-id="com.duckduckgo.mobile.android:id/primaryCta"]',
+        '//*[@resource-id="com.duckduckgo.mobile.android:id/bottomSheetPromoSecondaryButton"]',
+        '//*[@resource-id="com.duckduckgo.mobile.android:id/daxDialogDismissButton"]',
+        '//android.widget.Button[@text="Got it"]',
+        '//android.widget.Button[@text="Maybe later"]',
+      ],
+    });
   }
 }
 

--- a/scripts/duckduckgo.js
+++ b/scripts/duckduckgo.js
@@ -102,6 +102,7 @@ async function skipWelcomeDuckDuckGo() {
     await finishSession(driver, {
       adb,
       pkg: duckduckgo.pkg,
+      component: `${duckduckgo.pkg}/${duckduckgo.activity}`,
       // WebView app: the socket carries the pid, and the bare prefix would also
       // match other apps' WebViews
       socket: 'webview_devtools_remote',

--- a/scripts/duckduckgo.js
+++ b/scripts/duckduckgo.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 import { finishSession } from './browserReady.js';
@@ -19,12 +20,14 @@ const common = {
 };
 
 async function skipWelcomeDuckDuckGo() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.duckduckgo.mobile.android']);
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": "com.duckduckgo.mobile.android",
     "appium:appActivity": "com.duckduckgo.app.browser.BrowserActivity",

--- a/scripts/duckduckgo.js
+++ b/scripts/duckduckgo.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,12 +19,14 @@ const common = {
 };
 
 async function skipWelcomeDuckDuckGo() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.duckduckgo.mobile.android']);
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": "com.duckduckgo.mobile.android",
     "appium:appActivity": "com.duckduckgo.app.browser.BrowserActivity",

--- a/scripts/edge.js
+++ b/scripts/edge.js
@@ -23,12 +23,17 @@ async function skipWelcomeEdge() {
   const adbPort = resolveAdbPort();
   const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', edge.pkg]);
-  // Edge keeps Chromium's first-run machinery, so the FRE can be suppressed the
-  // same way as Chrome/Brave (honored on emulators and debuggable builds)
-  await adb.adbExec([
-    'shell',
-    "echo '_ --disable-fre --no-first-run' > /data/local/tmp/chrome-command-line",
-  ]);
+  // Optional: suppress Chromium's first-run experience. Off by default because
+  // /data/local/tmp/chrome-command-line is shared with Chrome and chromedriver,
+  // which writes its own chromeOptions.args there — clobbering it would change
+  // an unrelated Chrome session on the same device. Set CDP_SUPPRESS_FIRST_RUN=1
+  // to opt in; without it the readiness pass dismisses onboarding instead.
+  if (process.env.CDP_SUPPRESS_FIRST_RUN === '1') {
+    await adb.adbExec([
+      'shell',
+      "echo '_ --disable-fre --no-first-run' > /data/local/tmp/chrome-command-line",
+    ]);
+  }
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
@@ -216,6 +221,7 @@ async function skipWelcomeEdge() {
     await finishSession(driver, {
       adb,
       pkg: edge.pkg,
+      component: `${edge.pkg}/${edge.activity}`,
       socket: 'chrome_devtools_remote',
       selectors: [
         '//android.widget.Button[@text="Confirm"]',

--- a/scripts/edge.js
+++ b/scripts/edge.js
@@ -4,6 +4,7 @@ import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
+import { finishSession } from './browserReady.js';
 
 const START_APP_WAIT_DURATION = 60000;
 
@@ -20,6 +21,12 @@ const common = {
 async function skipWelcomeEdge() {
   const adb = await ADB.createADB();
   await adb.adbExec(['shell', 'pm', 'clear', edge.pkg]);
+  // Edge keeps Chromium's first-run machinery, so the FRE can be suppressed the
+  // same way as Chrome/Brave (honored on emulators and debuggable builds)
+  await adb.adbExec([
+    'shell',
+    "echo '_ --disable-fre --no-first-run' > /data/local/tmp/chrome-command-line",
+  ]);
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
@@ -85,7 +92,8 @@ async function skipWelcomeEdge() {
         try{
           notNowButton = await findElementWithWaitForCondition(
             'xpath',
-            '//android.widget.Button[@text="Not now"]'
+            '//android.widget.Button[@text="Not now"]',
+            15000
           );
           log.info(`Not Now button is ${JSON.stringify(notNowButton, null, 2)}`);
           found = true;
@@ -199,8 +207,18 @@ async function skipWelcomeEdge() {
         }
       }
     }
+  } catch (error) {
+    log.info(`walkthrough did not complete (${error.message}) — checking readiness anyway`);
   } finally {
-    await driver.deleteSession();
+    await finishSession(driver, {
+      adb,
+      pkg: edge.pkg,
+      socket: 'chrome_devtools_remote',
+      selectors: [
+        '//android.widget.Button[@text="Confirm"]',
+        '//*[@resource-id="com.android.permissioncontroller:id/permission_allow_button"]',
+      ],
+    });
   }
 
 

--- a/scripts/edge.js
+++ b/scripts/edge.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 import { finishSession } from './browserReady.js';
@@ -19,7 +20,8 @@ const common = {
 };
 
 async function skipWelcomeEdge() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', edge.pkg]);
   // Edge keeps Chromium's first-run machinery, so the FRE can be suppressed the
   // same way as Chrome/Brave (honored on emulators and debuggable builds)
@@ -31,6 +33,7 @@ async function skipWelcomeEdge() {
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": edge.pkg,
     "appium:appActivity": edge.activity,

--- a/scripts/edge.js
+++ b/scripts/edge.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,12 +19,14 @@ const common = {
 };
 
 async function skipWelcomeEdge() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', edge.pkg]);
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": edge.pkg,
     "appium:appActivity": edge.activity,

--- a/scripts/opera.js
+++ b/scripts/opera.js
@@ -4,6 +4,7 @@ import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
+import { clickSafely, finishSession } from './browserReady.js';
 
 const START_APP_WAIT_DURATION = 60000;
 
@@ -72,12 +73,20 @@ async function skipWelcomeOpera() {
         }
       };
 
-      const nextButton = await findElementWithWaitForCondition(
-        'id',
-        'com.opera.browser:id/continue_button'
-      );
-      log.info(`Next button is ${JSON.stringify(nextButton, null, 2)}`);
-      await driver.click(nextButton.ELEMENT);
+      // an Android system dialog (e.g. "System UI isn't responding") can cover the
+      // welcome screen, so this button is not guaranteed; readiness recovers
+      let nextButton = null;
+      try {
+        nextButton = await findElementWithWaitForCondition(
+          'id',
+          'com.opera.browser:id/continue_button'
+        );
+      } catch (error) {
+        log.info(`continue_button not present: ${error.message}`);
+      }
+      if (nextButton) {
+        await clickSafely(driver, nextButton);
+      }
 
       const skipButton = await findElementWithWaitForCondition(
         'id',
@@ -89,7 +98,7 @@ async function skipWelcomeOpera() {
       let found = false;
       
       while (attempt < MAX_RETRIES && !found) {
-        await driver.click(skipButton.ELEMENT);
+        await clickSafely(driver, skipButton);
         try{
           await findElementWithWaitForCondition(
             'xpath',
@@ -110,7 +119,7 @@ async function skipWelcomeOpera() {
       attempt = 0;
       found = false;
       while (attempt < MAX_RETRIES && !found) {
-        await driver.click(skipAgainButton.ELEMENT);
+        await clickSafely(driver, skipAgainButton);
         try{
           await findElementWithWaitForCondition(
             'xpath',
@@ -124,11 +133,20 @@ async function skipWelcomeOpera() {
       }
 
 
-      const allowButton = await findElementWithWaitForCondition(
-        'xpath',
-        '//android.widget.Button[@text="Allow"]'
-      );
-      await driver.click(allowButton.ELEMENT);
+      // the notification permission dialog is conditional
+      let allowButton = null;
+      try {
+        allowButton = await findElementWithWaitForCondition(
+          'xpath',
+          '//android.widget.Button[@text="Allow"]',
+          10000
+        );
+      } catch (error) {
+        log.info('Allow dialog not shown, skipping');
+      }
+      if (allowButton) {
+        await clickSafely(driver, allowButton);
+      }
 
       attempt = 0;
       found = false;
@@ -136,7 +154,7 @@ async function skipWelcomeOpera() {
       while (attempt < MAX_RETRIES && !found) {
         try{
           const doneButton = await findElementWithWaitForCondition('id', 'com.opera.browser:id/positive_button', 8000);
-          await driver.click(doneButton.ELEMENT);
+          await clickSafely(driver, doneButton);
           found = true;
         } catch(error) {
           log.info(`Done button not found, retrying after opening a url...`);
@@ -147,8 +165,20 @@ async function skipWelcomeOpera() {
         }
       }
     }
+  } catch (error) {
+    log.info(`walkthrough did not complete (${error.message}) — checking readiness anyway`);
   } finally {
-    await driver.deleteSession();
+    await finishSession(driver, {
+      adb,
+      pkg: opera.pkg,
+      socket: 'com.opera.browser.devtools',
+      selectors: [
+        '//android.widget.Button[@text="Accept and continue"]',
+        '//*[@resource-id="com.opera.browser:id/continue_button"]',
+        '//*[@resource-id="com.opera.browser:id/skip_button"]',
+        '//*[@resource-id="com.opera.browser:id/positive_button"]',
+      ],
+    });
   }
 }
 

--- a/scripts/opera.js
+++ b/scripts/opera.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,13 +19,15 @@ const common = {
 };
 
 async function skipWelcomeOpera() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.opera.browser']);
   //await adb.startApp(Object.assign({}, opera, common));
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": "com.opera.browser",
     "appium:appActivity": "com.opera.android.BrowserActivity",

--- a/scripts/opera.js
+++ b/scripts/opera.js
@@ -174,6 +174,7 @@ async function skipWelcomeOpera() {
     await finishSession(driver, {
       adb,
       pkg: opera.pkg,
+      component: `${opera.pkg}/${opera.activity}`,
       socket: 'com.opera.browser.devtools',
       selectors: [
         '//android.widget.Button[@text="Accept and continue"]',

--- a/scripts/opera.js
+++ b/scripts/opera.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 import { clickSafely, finishSession } from './browserReady.js';
@@ -19,13 +20,15 @@ const common = {
 };
 
 async function skipWelcomeOpera() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.opera.browser']);
   //await adb.startApp(Object.assign({}, opera, common));
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": "com.opera.browser",
     "appium:appActivity": "com.opera.android.BrowserActivity",

--- a/scripts/samsung.js
+++ b/scripts/samsung.js
@@ -93,6 +93,24 @@ async function skipWelcomeSamsung() {
         }
       } 
     }
+    // Samsung shows a privacy-notice alert on SBrowserMainActivity, after the
+    // intro rather than as part of it, so the branch above never sees it. It does
+    // not block the devtools socket — the page loads underneath — so the
+    // readiness pass has nothing to react to and the dialog would sit over the
+    // page for the whole session, swallowing taps meant for the content.
+    for (const selector of [
+      '//android.widget.Button[@resource-id="android:id/button1" and @text="Continue"]',
+      '//android.widget.Button[@text="Continue"]',
+    ]) {
+      try {
+        const dialogButton = await driver.findElement('xpath', selector);
+        await driver.click(dialogButton.ELEMENT);
+        log.info(`dismissed post-intro dialog via ${selector}`);
+        break;
+      } catch (error) {
+        // not shown on this launch
+      }
+    }
   } catch (error) {
     log.info(`walkthrough did not complete (${error.message}) — checking readiness anyway`);
   } finally {

--- a/scripts/samsung.js
+++ b/scripts/samsung.js
@@ -74,23 +74,40 @@ async function skipWelcomeSamsung() {
         }
       };
 
+      // The agree button is not the same on every build: newer intros label it
+      // "Continue" and do not expose help_intro_legal_agree_button. Try the id
+      // first, then the label.
+      //
+      // Note the intro also carries a "Close app" button beside it, and a
+      // SystemUI ANR dialog ("Close app" / "Wait") can sit on top of the whole
+      // screen. Only ever match the affordances below by exact text — clicking
+      // "Close app" would kill the browser we are setting up.
+      const INTRO_SELECTORS = [
+        ['id', 'com.sec.android.app.sbrowser:id/help_intro_legal_agree_button'],
+        ['xpath', '//android.widget.Button[@text="Continue"]'],
+        ['xpath', '//android.widget.Button[@text="Agree"]'],
+      ];
+
       const MAX_RETRIES = 2;
       let attempt = 0;
-      
-      while (attempt < MAX_RETRIES) {
-        try{
-          const buttonToClick = await findElementWithWaitForCondition(
-            'id',
-            'com.sec.android.app.sbrowser:id/help_intro_legal_agree_button'
-          );
-          log.info(`Button to click is ${JSON.stringify(buttonToClick, null, 2)}`);
-          await driver.click(buttonToClick.ELEMENT);
 
-        } catch(error) {
-          log.info(`Continue button not found, retrying...`);
-        } finally {
-          attempt++;
+      while (attempt < MAX_RETRIES) {
+        let clicked = false;
+        for (const [strategy, selector] of INTRO_SELECTORS) {
+          try {
+            const buttonToClick = await findElementWithWaitForCondition(strategy, selector, 4000);
+            await driver.click(buttonToClick.ELEMENT);
+            log.info(`intro dismissed via ${strategy}: ${selector}`);
+            clicked = true;
+            break;
+          } catch (error) {
+            // try the next shape
+          }
         }
+        if (!clicked) {
+          log.info('intro button not found on this attempt');
+        }
+        attempt++;
       } 
     }
     // Samsung shows a privacy-notice alert on SBrowserMainActivity, after the

--- a/scripts/samsung.js
+++ b/scripts/samsung.js
@@ -4,6 +4,7 @@ import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
+import { finishSession } from './browserReady.js';
 
 const START_APP_WAIT_DURATION = 60000;
 
@@ -89,8 +90,19 @@ async function skipWelcomeSamsung() {
         }
       } 
     }
+  } catch (error) {
+    log.info(`walkthrough did not complete (${error.message}) — checking readiness anyway`);
   } finally {
-    await driver.deleteSession();
+    await finishSession(driver, {
+      adb,
+      pkg: samsung.pkg,
+      socket: 'Terrace_devtools_remote',
+      selectors: [
+        '//*[@resource-id="com.sec.android.app.sbrowser:id/help_intro_legal_agree_button"]',
+        '//android.widget.Button[@text="Agree"]',
+        '//android.widget.Button[@text="I agree"]',
+      ],
+    });
   }
 }
 

--- a/scripts/samsung.js
+++ b/scripts/samsung.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 import { finishSession } from './browserReady.js';
@@ -19,12 +20,14 @@ const common = {
 };
 
 async function skipWelcomeSamsung() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', samsung.pkg]);
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": samsung.pkg,
     "appium:appActivity": samsung.activity,

--- a/scripts/samsung.js
+++ b/scripts/samsung.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,12 +19,14 @@ const common = {
 };
 
 async function skipWelcomeSamsung() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', samsung.pkg]);
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": samsung.pkg,
     "appium:appActivity": samsung.activity,

--- a/scripts/samsung.js
+++ b/scripts/samsung.js
@@ -99,6 +99,7 @@ async function skipWelcomeSamsung() {
     await finishSession(driver, {
       adb,
       pkg: samsung.pkg,
+      component: `${samsung.pkg}/${samsung.activity}`,
       socket: 'Terrace_devtools_remote',
       selectors: [
         '//*[@resource-id="com.sec.android.app.sbrowser:id/help_intro_legal_agree_button"]',

--- a/src/adb.js
+++ b/src/adb.js
@@ -1,4 +1,4 @@
-import { ADB, getSdkRootFromEnv } from 'appium-adb';
+import { ADB, DEFAULT_ADB_PORT, getSdkRootFromEnv } from 'appium-adb';
 import { fs } from '@appium/support';
 import getPort from 'get-port';
 import log from './logger';
@@ -16,14 +16,28 @@ const DEVTOOLS_SOCKET_MAP = {
   terrance: 'com.sec.android.app.sbrowser_devtools_remote',
 };
 
-export async function getAdb() {
+/**
+ * Resolve the adb server port: explicit value wins, then CDP_ADB_PORT (used by
+ * the skip-welcome scripts, which run as separate processes and receive no
+ * capabilities), then adb's default.
+ */
+export function resolveAdbPort(adbPort) {
+  const candidate = adbPort ?? process.env.CDP_ADB_PORT;
+  const port = parseInt(candidate, 10);
+  return Number.isInteger(port) && port > 0 ? port : DEFAULT_ADB_PORT;
+}
+
+export async function getAdb(adbPort) {
   try {
     if (!adb) {
-      adb = await ADB.createADB();
+      const port = resolveAdbPort(adbPort);
+      log.info(`Using adb server port ${port}`);
+      adb = await ADB.createADB({ adbPort: port });
     }
   } catch (e) {
     console.log(e);
   }
+  return adb;
 }
 
 export async function requireSdkRoot() {
@@ -87,14 +101,14 @@ async function getDuckDuckGoPid(browser = 'duckduckgo') {
   }
 }
 
-const PACKAGES = {
-  chrome: 'com.android.chrome',
-  brave: 'com.brave.browser',
-  opera: 'com.opera.browser',
-  duckduckgo: 'com.duckduckgo.mobile.android',
-  samsung: 'com.sec.android.app.sbrowser',
-  terrance: 'com.sec.android.app.sbrowser',
-  edge: 'com.microsoft.emmx',
+const BROWSERS = {
+  chrome: { pkg: 'com.android.chrome', activity: 'com.google.android.apps.chrome.Main' },
+  brave: { pkg: 'com.brave.browser', activity: 'com.google.android.apps.chrome.Main' },
+  opera: { pkg: 'com.opera.browser', activity: 'com.opera.android.BrowserActivity' },
+  duckduckgo: { pkg: 'com.duckduckgo.mobile.android', activity: 'com.duckduckgo.app.browser.BrowserActivity' },
+  samsung: { pkg: 'com.sec.android.app.sbrowser', activity: 'com.sec.android.app.sbrowser.SBrowserMainActivity' },
+  terrance: { pkg: 'com.sec.android.app.sbrowser', activity: 'com.sec.android.app.sbrowser.SBrowserMainActivity' },
+  edge: { pkg: 'com.microsoft.emmx', activity: 'com.microsoft.ruby.Main' },
 };
 
 /**
@@ -106,7 +120,7 @@ const PACKAGES = {
  * existing port forward is left pointing at a socket that no longer exists.
  */
 export async function openStartUrl(browser, url = 'https://www.appium.io') {
-  const pkg = PACKAGES[browser];
+  const pkg = BROWSERS[browser]?.pkg;
   if (!pkg) {
     return;
   }
@@ -114,65 +128,15 @@ export async function openStartUrl(browser, url = 'https://www.appium.io') {
 }
 
 export async function startApplication(browser = 'chrome') {
-  const common = {
+  const target = BROWSERS[browser];
+  if (!target) {
+    return;
+  }
+  log.info(`Starting ${browser}`);
+  await adb.startApp({
+    pkg: target.pkg,
+    activity: target.activity,
     waitDuration: START_APP_WAIT_DURATION,
     optionalIntentArguments: '-d www.appium.io',
-  };
-  const chrome = {
-    pkg: 'com.android.chrome',
-    activity: 'com.google.android.apps.chrome.Main',
-  };
-
-  const terrance = {
-    pkg: 'com.sec.android.app.sbrowser',
-    activity: 'com.sec.android.app.sbrowser.SBrowserMainActivity',
-  };
-
-  const brave = {
-    pkg: 'com.brave.browser',
-    activity: 'com.google.android.apps.chrome.Main',
-  };
-
-  const opera = {
-    pkg: 'com.opera.browser',
-    activity: 'com.opera.android.BrowserActivity',
-  };
-
-  const duckduckgo = {
-    pkg: 'com.duckduckgo.mobile.android',
-    activity: 'com.duckduckgo.app.browser.BrowserActivity',
-  };
-
-  const samsung = {
-    pkg: 'com.sec.android.app.sbrowser',
-    activity: 'com.sec.android.app.sbrowser.SBrowserMainActivity',
-  };
-  
-  const edge = {
-    pkg: 'com.microsoft.emmx',
-    activity: 'com.microsoft.ruby.Main',
-  };
-
-  if (browser === 'chrome') {
-    log.info(`Starting Chrome`);
-    await adb.startApp(Object.assign({}, chrome, common));
-  } else if (browser === 'terrance') {
-    log.info(`Starting Terrance`);
-    await adb.startApp(Object.assign({}, terrance, common));
-  } else if (browser === 'brave') {
-    log.info(`Starting Brave`);
-    await adb.startApp(Object.assign({}, brave, common));
-  } else if (browser === 'opera') {
-    log.info(`Starting Opera`);
-    await adb.startApp(Object.assign({}, opera, common));
-  } else if (browser === 'duckduckgo') {
-    log.info(`Starting DuckDuckGo`);
-    await adb.startApp(Object.assign({}, duckduckgo, common));
-  } else if (browser === 'samsung') {
-    log.info(`Starting Samsung Browser`);
-    await adb.startApp(Object.assign({}, samsung, common));
-  } else if (browser === 'edge') {
-    log.info(`Starting MS Edge`);
-    await adb.startApp(Object.assign({}, edge, common));
-  }
+  });
 }

--- a/src/adb.js
+++ b/src/adb.js
@@ -124,7 +124,12 @@ export async function openStartUrl(browser, url = 'https://www.appium.io') {
   if (!pkg) {
     return;
   }
-  await adb.adbExec(['shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url, pkg]);
+  // -n <component>: a bare trailing package is not honoured by am, so the intent
+  // would go to whichever browser handles VIEW by default rather than this one
+  await adb.adbExec([
+    'shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url,
+    '-n', `${pkg}/${BROWSERS[browser].activity}`,
+  ]);
 }
 
 export async function startApplication(browser = 'chrome') {

--- a/src/adb.js
+++ b/src/adb.js
@@ -76,7 +76,10 @@ async function getDuckDuckGoPid(browser = 'duckduckgo') {
   const packageName = 'com.duckduckgo.mobile.android';
   try {
     const output = await adb.adbExec(['shell', 'pidof', packageName]);
-    const pid = output.trim();
+    // pidof lists every process of the package; the socket belongs to the first
+    // (browser) process, and passing the whole list builds an unusable socket
+    // name like webview_devtools_remote_1234 5678
+    const pid = String(output).trim().split(/\s+/)[0];
     return pid || null;
   } catch (err) {
     console.error(`Unable to get PID for ${browser}:`, err.message);

--- a/src/adb.js
+++ b/src/adb.js
@@ -84,6 +84,32 @@ async function getDuckDuckGoPid(browser = 'duckduckgo') {
   }
 }
 
+const PACKAGES = {
+  chrome: 'com.android.chrome',
+  brave: 'com.brave.browser',
+  opera: 'com.opera.browser',
+  duckduckgo: 'com.duckduckgo.mobile.android',
+  samsung: 'com.sec.android.app.sbrowser',
+  terrance: 'com.sec.android.app.sbrowser',
+  edge: 'com.microsoft.emmx',
+};
+
+/**
+ * Open the start URL in an already-running browser.
+ *
+ * Deliberately a plain VIEW intent rather than startApplication: the latter
+ * passes -S, which force-stops the process. That changes the pid, and for
+ * WebView-based browsers the devtools socket name carries the pid, so an
+ * existing port forward is left pointing at a socket that no longer exists.
+ */
+export async function openStartUrl(browser, url = 'https://www.appium.io') {
+  const pkg = PACKAGES[browser];
+  if (!pkg) {
+    return;
+  }
+  await adb.adbExec(['shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url, pkg]);
+}
+
 export async function startApplication(browser = 'chrome') {
   const common = {
     waitDuration: START_APP_WAIT_DURATION,

--- a/src/adb.js
+++ b/src/adb.js
@@ -1,4 +1,4 @@
-import { ADB, getSdkRootFromEnv } from 'appium-adb';
+import { ADB, DEFAULT_ADB_PORT, getSdkRootFromEnv } from 'appium-adb';
 import { fs } from '@appium/support';
 import getPort from 'get-port';
 import log from './logger';
@@ -16,14 +16,28 @@ const DEVTOOLS_SOCKET_MAP = {
   terrance: 'com.sec.android.app.sbrowser_devtools_remote',
 };
 
-export async function getAdb() {
+/**
+ * Resolve the adb server port: explicit value wins, then CDP_ADB_PORT (used by
+ * the skip-welcome scripts, which run as separate processes and receive no
+ * capabilities), then adb's default.
+ */
+export function resolveAdbPort(adbPort) {
+  const candidate = adbPort ?? process.env.CDP_ADB_PORT;
+  const port = parseInt(candidate, 10);
+  return Number.isInteger(port) && port > 0 ? port : DEFAULT_ADB_PORT;
+}
+
+export async function getAdb(adbPort) {
   try {
     if (!adb) {
-      adb = await ADB.createADB();
+      const port = resolveAdbPort(adbPort);
+      log.info(`Using adb server port ${port}`);
+      adb = await ADB.createADB({ adbPort: port });
     }
   } catch (e) {
     console.log(e);
   }
+  return adb;
 }
 
 export async function requireSdkRoot() {

--- a/src/driver.js
+++ b/src/driver.js
@@ -71,9 +71,21 @@ class AppiumCDPDriver extends BaseDriver {
         maxTimeout: 10000,
       }
     );
-    const target = data.find((target) => {
-      return target.url.includes('appium.io');
-    });
+    // Prefer the page we launched, but do not require it: after a redirect, a
+    // new tab, or an onboarding page the list holds other targets, and reading
+    // webSocketDebuggerUrl off undefined fails the session with an opaque error.
+    let target = data.find((t) => t.url && t.url.includes('appium.io'));
+    if (!target) {
+      target =
+        data.find((t) => t.type === 'page' && t.webSocketDebuggerUrl) ||
+        data.find((t) => t.webSocketDebuggerUrl);
+      log.info(`No appium.io target; falling back to ${target ? target.url || target.type : 'none'}`);
+    }
+    if (!target) {
+      throw new Error(
+        `No CDP target with a webSocketDebuggerUrl in ${JSON.stringify(data)}`
+      );
+    }
     log.info(`Target found: ${target.webSocketDebuggerUrl}`);
     await openBrowser({
       port: port,

--- a/src/driver.js
+++ b/src/driver.js
@@ -55,6 +55,15 @@ class AppiumCDPDriver extends BaseDriver {
           log.info(`CDP response: ${JSON.stringify(data)}`);
 
           if (!Array.isArray(data) || data.length === 0) {
+            // The socket is up but the browser holds no debuggable page — common
+            // for WebView-based browsers just after launch. Retrying the fetch
+            // alone changes nothing, so nudge the browser into opening one.
+            log.info('Debug list is empty, relaunching the browser to open a page');
+            try {
+              await startApplication(browser);
+            } catch (launchError) {
+              log.info(`Relaunch failed: ${launchError.message}`);
+            }
             throw new Error('Debug list is empty or invalid');
           }
 

--- a/src/driver.js
+++ b/src/driver.js
@@ -19,6 +19,10 @@ class AppiumCDPDriver extends BaseDriver {
         presence: true,
         isString: true,
       },
+      adbPort: {
+        isNumber: false,
+        presence: false,
+      },
     };
   }
 
@@ -26,7 +30,7 @@ class AppiumCDPDriver extends BaseDriver {
     console.log(await getConfig('local'));
     const res = await super.createSession(w3cCaps);
     const browser = w3cCaps.alwaysMatch['browserName'];
-    await getAdb();
+    await getAdb(w3cCaps.alwaysMatch['appium:adbPort']);
     let port;
     if (browser === 'duckduckgo') {
       await startApplication(browser);

--- a/src/driver.js
+++ b/src/driver.js
@@ -1,5 +1,5 @@
 import { BaseDriver, errors } from '@appium/base-driver';
-import { getAdb, adbExec, startApplication } from './adb';
+import { getAdb, adbExec, startApplication, openStartUrl } from './adb';
 import { openBrowser, getConfig, goto } from 'taiko';
 import commands from './commands';
 import log from './logger';
@@ -58,11 +58,11 @@ class AppiumCDPDriver extends BaseDriver {
             // The socket is up but the browser holds no debuggable page — common
             // for WebView-based browsers just after launch. Retrying the fetch
             // alone changes nothing, so nudge the browser into opening one.
-            log.info('Debug list is empty, relaunching the browser to open a page');
+            log.info('Debug list is empty, opening the start URL to create a page');
             try {
-              await startApplication(browser);
+              await openStartUrl(browser);
             } catch (launchError) {
-              log.info(`Relaunch failed: ${launchError.message}`);
+              log.info(`Could not open the start URL: ${launchError.message}`);
             }
             throw new Error('Debug list is empty or invalid');
           }

--- a/test/adb-port.spec.js
+++ b/test/adb-port.spec.js
@@ -1,0 +1,51 @@
+const { expect } = require('chai');
+const { resolveAdbPort } = require('../build/src/adb.js');
+
+const DEFAULT = 5037;
+
+describe('resolveAdbPort', function () {
+  let previous;
+
+  beforeEach(function () {
+    previous = process.env.CDP_ADB_PORT;
+    delete process.env.CDP_ADB_PORT;
+  });
+
+  afterEach(function () {
+    if (previous === undefined) {
+      delete process.env.CDP_ADB_PORT;
+    } else {
+      process.env.CDP_ADB_PORT = previous;
+    }
+  });
+
+  it('defaults to 5037 when nothing is supplied', function () {
+    expect(resolveAdbPort(undefined)).to.equal(DEFAULT);
+  });
+
+  it('defaults to 5037 for unusable values', function () {
+    for (const value of [null, '', 'abc', 0, -1]) {
+      expect(resolveAdbPort(value)).to.equal(DEFAULT);
+    }
+  });
+
+  it('accepts the capability as a number or a string', function () {
+    expect(resolveAdbPort(5038)).to.equal(5038);
+    expect(resolveAdbPort('5038')).to.equal(5038);
+  });
+
+  it('falls back to CDP_ADB_PORT when no capability is given', function () {
+    process.env.CDP_ADB_PORT = '5040';
+    expect(resolveAdbPort(undefined)).to.equal(5040);
+  });
+
+  it('prefers the capability over the environment variable', function () {
+    process.env.CDP_ADB_PORT = '5040';
+    expect(resolveAdbPort(5041)).to.equal(5041);
+  });
+
+  it('ignores an unusable environment variable', function () {
+    process.env.CDP_ADB_PORT = 'nope';
+    expect(resolveAdbPort(undefined)).to.equal(DEFAULT);
+  });
+});

--- a/test/browser-ready.spec.js
+++ b/test/browser-ready.spec.js
@@ -1,0 +1,38 @@
+const { expect } = require('chai');
+const { pickPageTargets } = require('../build/scripts/browserReady.js');
+
+// Shape taken from a real /json/list response on Android: one page plus a
+// worker, both carrying a webSocketDebuggerUrl.
+const PAGE = {
+  type: 'page',
+  url: 'http://appium.io/docs/en/latest/',
+  webSocketDebuggerUrl: 'ws://localhost:60107/devtools/page/0',
+};
+const WORKER = {
+  type: 'worker',
+  url: '',
+  webSocketDebuggerUrl: 'ws://localhost:60107/devtools/page/13B8F77E',
+};
+
+describe('pickPageTargets', function () {
+  it('selects page targets', function () {
+    expect(pickPageTargets([PAGE, WORKER])).to.deep.equal([PAGE]);
+  });
+
+  it('does not treat a worker as a page', function () {
+    // the browser has a devtools socket but nothing to attach to; accepting this
+    // is what produced "Debug list is empty or invalid" later in session creation
+    expect(pickPageTargets([WORKER])).to.have.lengthOf(0);
+  });
+
+  it('ignores targets without a debugger url', function () {
+    expect(pickPageTargets([{ type: 'page', url: 'about:blank' }])).to.have.lengthOf(0);
+  });
+
+  it('tolerates an empty or malformed list', function () {
+    expect(pickPageTargets([])).to.have.lengthOf(0);
+    expect(pickPageTargets(null)).to.have.lengthOf(0);
+    expect(pickPageTargets(undefined)).to.have.lengthOf(0);
+    expect(pickPageTargets([null, undefined])).to.have.lengthOf(0);
+  });
+});


### PR DESCRIPTION
Follow-up to #18, which fixed Brave's first-run race. Soaking all five browsers surfaced the same class of failure in the other scripts, plus three further defects. Also folds in a small, independent change: the adb server port is now configurable.

## Problem

Sessions fail intermittently at creation with `socket hang up` or `Debug list is empty or invalid` on `/json/list`.

The `skip-welcome-*` scripts clear the browser profile — which guarantees first-run onboarding appears — then dismiss it by clicking a hard-coded sequence of controls. That choreography is racy in practice:

- **Dialog order and content vary per launch.** Brave's first dialog was `android:id/button2` on one run and `com.brave.browser:id/btn_negative` on the next.
- **Some stages are conditional.** Opera unconditionally waited 30 s for the "Allow" notification prompt; when it does not appear the script threw with onboarding still on screen.
- **Edge's first-run screen is web-rendered** and sometimes shows none of the expected controls ("Not now" missed 21 times in one run).
- **An Android system dialog can cover everything.** A page-source dump during a failure showed `"System UI isn't responding" / "Close app" / "Wait"` — a SystemUI ANR over the welcome screen. No expected element is findable, and restarting the *browser* does not clear it.

When any of these happen the browser never opens its devtools socket. Worse, most of these scripts caught every error and still exited 0, so the caller reported success and started a session that could not work.

## Fix

Converge on the end state the driver needs instead of requiring a fixed sequence. New `scripts/browserReady.js`:

- dismisses whatever is on screen from a set of known-safe controls (ANR "Wait" first, so a system dialog is cleared before anything beneath it is touched);
- relaunches the browser when nothing is dismissable;
- treats the browser as ready only when **onboarding is gone, the devtools endpoint belongs to this package, and `/json/list` reports an attachable `page` target**. Ownership is checked through the `Android-Package` field of `/json/version`, since chrome, brave and edge share the `chrome_devtools_remote` name; the page check ignores `worker` targets, which also carry a `webSocketDebuggerUrl`. The list is polled, not slept on;
- **throws if the browser never becomes ready**, so a failed setup is visible immediately instead of surfacing later as an opaque session error.

| Browser | Change |
|---|---|
| edge | Optional FRE suppression, off by default (see below). Walkthrough and readiness pass handle it otherwise. |
| opera | `continue_button` and the Allow dialog are optional; clicks no longer abort the walkthrough when the screen changes underneath them. Opera does **not** honour the Chromium flag (its onboarding is `com.opera.android.startup.WelcomeActivity`), so it relies on the readiness pass. |
| duckduckgo | Readiness uses the pid-scoped `webview_devtools_remote_<pid>` socket — the bare prefix also matches other apps' WebViews. |
| samsung | Readiness check added; walkthrough unchanged. |
| brave | Shares the readiness helper. The flag written by #18 is now opt-in (see below). |

### `src/driver.js`

1. **Target selection.** `data.find((t) => t.url.includes('appium.io'))` was a hard requirement; after a redirect, a new tab, or an onboarding page there is no such target and the session failed with `Cannot read properties of undefined (reading 'webSocketDebuggerUrl')`. Now falls back to any page target with a debugger URL, with a clear error if there is none. This reproduced independently on a second host after ~150 clean runs.
2. **Empty debug list.** When `/json/list` returned `[]` the driver retried the fetch ten times, but nothing in that loop made a page appear. It now opens the start URL between attempts, via a new `openStartUrl()` — deliberately a plain VIEW intent rather than `startApplication()`, because the latter passes `-S` and force-stops the process; for WebView browsers the pid changes and the existing port forward is left pointing at a dead socket.

### Configurable adb server port

The driver could only talk to adb on 5037: `ADB.createADB()` was called with no options in six places, and the `appium:adbPort` capability that callers already send was discarded (sessions logged it under *"capabilities were provided, but are not recognized"*). The port now resolves as **`appium:adbPort` → `CDP_ADB_PORT` → 5037**.

The environment variable is not redundant: the `skip-welcome-*` scripts run as separate processes and never see the session's capabilities, so a capability-only fix would leave the browser setup on the requested port while the walkthrough silently used 5037. Each script also passes the resolved port into its UiAutomator2 session, so both halves address the same adb server.

**No behaviour change when neither is set** — `resolveAdbPort()` returns 5037, and unusable values fall back to it rather than producing a broken `-P`. Covered by tests.

Verified on an Android emulator host, against a live Android 15 emulator:

| Case | Resolved | adb argv | Result |
|---|---|---|---|
| Neither set | 5037 | `-P 5037` | `adb shell getprop` → `sdk=35` |
| `CDP_ADB_PORT=5038`, **default server killed** | 5038 | `-P 5038` | `sdk=35`, with 0 listeners on 5037 for the whole case |
| `appium:adbPort=5038`, default server killed | 5038 | `-P 5038` | `sdk=35` |
| `CDP_ADB_PORT=5039` pointed at a non-adb listener, 5037 healthy | 5039 | `-P 5039` | fails — no silent fallback |

The second case is the load-bearing one: with no adb server on 5037 at all, the 5038 server answered with a device entry (`127.0.0.1:5555`) that only it had. The last case is the inverse — a healthy 5037 was deliberately left running, and the driver still failed on the port it was told to use rather than quietly succeeding elsewhere.

## Verification

A controlled A/B on Android 15 and 16 emulators (Appium 2.6.0), five browsers rotating, one session at a time, **400 tests in four builds of 100**:

| Group | Driver | Tests | Passed | Session-creation failures |
|---|---|---|---|---|
| host A | **this branch** | 100 | 100 | **0** |
| host B | **this branch** | 100 | 100 | **0** |
| long-lived machines | current release | 100 | 84 | **16 (16%)** |
| freshly provisioned machines | current release | 100 | 100 | **0** |

Every failure was brave (13) or Edge (3) — exactly the two browsers whose first-run experience this change suppresses. Opera, DuckDuckGo and Samsung never failed anywhere. The freshly-provisioned control is the useful one: it ran the **same current release** and was clean, because a new machine has no stale first-run state — which isolates the cause to onboarding state rather than the driver, the machine, or the OS version.

FRE suppression was measured separately: 31 launches on freshly-cleared profiles across brave and Edge, **0** first-run screens. Note the 400-test run above had suppression **enabled**; the default path (readiness pass only, no file written) has not been measured at that scale for brave and edge, though it is the path the other three browsers used throughout.

Tests: `test/browser-ready.spec.js` (page-vs-worker target selection) and `test/adb-port.spec.js` (port resolution, including the 5037 default) — 10 cases, all passing.

## Notes for the reviewer

- **First-run suppression is opt-in.** `/data/local/tmp/chrome-command-line` is shared with Chrome, and chromedriver writes its own `chromeOptions.args` there, so writing it for brave or edge could change an unrelated Chrome session on the same device. Nothing is written unless `CDP_SUPPRESS_FIRST_RUN=1` is set; by default onboarding is handled by the readiness pass, as it is for opera, duckduckgo and samsung. Note this differs from #18, which wrote the file unconditionally for brave.
- **Whether brave and edge honour a package-specific command-line file is unknown.** It would avoid the shared path entirely, but I could not establish it: the only emulators available for testing are inside sessions that pin the foreground app, so a second browser cannot be launched in them. If you know the answer, this could become a per-package file and the opt-in would be unnecessary.
- **`am start` does not honour a bare trailing package.** Both `openStartUrl()` and the readiness helper's page-open step used that form and were opening the start URL in whichever browser handles VIEW by default; they now pass `-n <package>/<activity>`. This was invisible in practice because a page was usually already present from the preceding launch.
- **The ownership check is best-effort.** `/json/version` on some forks may omit `Android-Package`; when the field is absent the endpoint is accepted, since the socket name is browser-specific for everything except the chrome/brave/edge trio.
- **Samsung has no failure evidence behind it** — it never failed in 400 tests. The readiness check was added for consistency, as its walkthrough has the same swallow-everything shape as the others.
- Readiness costs a few adb calls and a short poll per setup on the happy path; the previous fixed 4 s sleep was removed in favour of polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


