### PR TITLE
DRAFT: make the adb server port configurable (appium:adbPort / CDP_ADB_PORT)

### DIFF
--- a/scripts/brave.js
+++ b/scripts/brave.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,7 +19,8 @@ const common = {
 };
 
 async function skipWelcomeBrave() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.brave.browser']);
   // Suppress the first-run Welcome walkthrough (honored on emulators/debuggable builds;
   // harmless no-op elsewhere, where the UI walkthrough below still handles it)
@@ -30,6 +32,7 @@ async function skipWelcomeBrave() {
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": "com.brave.browser",
     "appium:appActivity": "com.google.android.apps.chrome.Main",

--- a/scripts/duckduckgo.js
+++ b/scripts/duckduckgo.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,12 +19,14 @@ const common = {
 };
 
 async function skipWelcomeDuckDuckGo() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.duckduckgo.mobile.android']);
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": "com.duckduckgo.mobile.android",
     "appium:appActivity": "com.duckduckgo.app.browser.BrowserActivity",

--- a/scripts/edge.js
+++ b/scripts/edge.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,12 +19,14 @@ const common = {
 };
 
 async function skipWelcomeEdge() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', edge.pkg]);
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": edge.pkg,
     "appium:appActivity": edge.activity,

--- a/scripts/opera.js
+++ b/scripts/opera.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,13 +19,15 @@ const common = {
 };
 
 async function skipWelcomeOpera() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', 'com.opera.browser']);
   //await adb.startApp(Object.assign({}, opera, common));
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": "com.opera.browser",
     "appium:appActivity": "com.opera.android.BrowserActivity",

--- a/scripts/samsung.js
+++ b/scripts/samsung.js
@@ -2,6 +2,7 @@
 
 import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { ADB } from 'appium-adb';
+import { resolveAdbPort } from '../src/adb.js';
 import log from '../src/logger.js';
 import { waitForCondition } from 'asyncbox';
 
@@ -18,12 +19,14 @@ const common = {
 };
 
 async function skipWelcomeSamsung() {
-  const adb = await ADB.createADB();
+  const adbPort = resolveAdbPort();
+  const adb = await ADB.createADB({ adbPort });
   await adb.adbExec(['shell', 'pm', 'clear', samsung.pkg]);
   const driver = new AndroidUiautomator2Driver();
   const caps = {
     platformName: "Android",
     "appium:automationName": "UiAutomator2",
+    "appium:adbPort": adbPort,
     "appium:deviceName": "Android Device",
     "appium:appPackage": samsung.pkg,
     "appium:appActivity": samsung.activity,

--- a/src/adb.js
+++ b/src/adb.js
@@ -1,4 +1,4 @@
-import { ADB, getSdkRootFromEnv } from 'appium-adb';
+import { ADB, DEFAULT_ADB_PORT, getSdkRootFromEnv } from 'appium-adb';
 import { fs } from '@appium/support';
 import getPort from 'get-port';
 import log from './logger';
@@ -16,14 +16,28 @@ const DEVTOOLS_SOCKET_MAP = {
   terrance: 'com.sec.android.app.sbrowser_devtools_remote',
 };
 
-export async function getAdb() {
+/**
+ * Resolve the adb server port: explicit value wins, then CDP_ADB_PORT (used by
+ * the skip-welcome scripts, which run as separate processes and receive no
+ * capabilities), then adb's default.
+ */
+export function resolveAdbPort(adbPort) {
+  const candidate = adbPort ?? process.env.CDP_ADB_PORT;
+  const port = parseInt(candidate, 10);
+  return Number.isInteger(port) && port > 0 ? port : DEFAULT_ADB_PORT;
+}
+
+export async function getAdb(adbPort) {
   try {
     if (!adb) {
-      adb = await ADB.createADB();
+      const port = resolveAdbPort(adbPort);
+      log.info(`Using adb server port ${port}`);
+      adb = await ADB.createADB({ adbPort: port });
     }
   } catch (e) {
     console.log(e);
   }
+  return adb;
 }
 
 export async function requireSdkRoot() {

--- a/src/driver.js
+++ b/src/driver.js
@@ -19,6 +19,10 @@ class AppiumCDPDriver extends BaseDriver {
         presence: true,
         isString: true,
       },
+      adbPort: {
+        isNumber: false,
+        presence: false,
+      },
     };
   }
 
@@ -26,7 +30,7 @@ class AppiumCDPDriver extends BaseDriver {
     console.log(await getConfig('local'));
     const res = await super.createSession(w3cCaps);
     const browser = w3cCaps.alwaysMatch['browserName'];
-    await getAdb();
+    await getAdb(w3cCaps.alwaysMatch['appium:adbPort']);
     let port;
     if (browser === 'duckduckgo') {
       await startApplication(browser);

--- a/test/adb-port.spec.js
+++ b/test/adb-port.spec.js
@@ -1,0 +1,51 @@
+const { expect } = require('chai');
+const { resolveAdbPort } = require('../build/src/adb.js');
+
+const DEFAULT = 5037;
+
+describe('resolveAdbPort', function () {
+  let previous;
+
+  beforeEach(function () {
+    previous = process.env.CDP_ADB_PORT;
+    delete process.env.CDP_ADB_PORT;
+  });
+
+  afterEach(function () {
+    if (previous === undefined) {
+      delete process.env.CDP_ADB_PORT;
+    } else {
+      process.env.CDP_ADB_PORT = previous;
+    }
+  });
+
+  it('defaults to 5037 when nothing is supplied', function () {
+    expect(resolveAdbPort(undefined)).to.equal(DEFAULT);
+  });
+
+  it('defaults to 5037 for unusable values', function () {
+    for (const value of [null, '', 'abc', 0, -1]) {
+      expect(resolveAdbPort(value)).to.equal(DEFAULT);
+    }
+  });
+
+  it('accepts the capability as a number or a string', function () {
+    expect(resolveAdbPort(5038)).to.equal(5038);
+    expect(resolveAdbPort('5038')).to.equal(5038);
+  });
+
+  it('falls back to CDP_ADB_PORT when no capability is given', function () {
+    process.env.CDP_ADB_PORT = '5040';
+    expect(resolveAdbPort(undefined)).to.equal(5040);
+  });
+
+  it('prefers the capability over the environment variable', function () {
+    process.env.CDP_ADB_PORT = '5040';
+    expect(resolveAdbPort(5041)).to.equal(5041);
+  });
+
+  it('ignores an unusable environment variable', function () {
+    process.env.CDP_ADB_PORT = 'nope';
+    expect(resolveAdbPort(undefined)).to.equal(DEFAULT);
+  });
+});


### PR DESCRIPTION
> **DRAFT — not ready to merge.** Small and self-contained, but untested against a non-default adb server; see Testing below.

## Problem

The driver can only talk to an adb server on the default port 5037.

`ADB.createADB()` is called with no options in six places (`src/adb.js` plus each `scripts/*.js`), so appium-adb falls back to `DEFAULT_ADB_PORT`. Callers that already pass `appium:adbPort` get it silently dropped — a session log shows it under:

```
The following capabilities were provided, but are not recognized by Appium:
  adbPort
```

That rules out any setup where adb does not listen on 5037: several adb servers on one machine, a sandboxed CI agent, or a device-farm host running one server per device.

## Change

The port is resolved in this order:

1. `appium:adbPort` capability
2. `CDP_ADB_PORT` environment variable
3. adb's default (5037)

```js
export function resolveAdbPort(adbPort) {
  const candidate = adbPort ?? process.env.CDP_ADB_PORT;
  const port = parseInt(candidate, 10);
  return Number.isInteger(port) && port > 0 ? port : DEFAULT_ADB_PORT;
}
```

`getAdb()` takes the port and passes it to `ADB.createADB({ adbPort })`, which puts `-P <port>` on every adb invocation — including the `forward` that opens the devtools tunnel.

### Why the environment variable is not redundant

The `skip-welcome-*` scripts run as **separate processes**, launched via `appium driver run cdp-driver skip-welcome-<browser>`. They never see the session's capabilities, so a capability-only fix would leave the browser setup on the requested port while the onboarding walkthrough kept using 5037 — half-working in a way that is awkward to debug. Each script now resolves the port itself and also passes it into its UiAutomator2 session (`appium:adbPort`), so both halves address the same adb server.

## Scope

| File | Change |
|---|---|
| `src/adb.js` | `resolveAdbPort()`; `getAdb(adbPort)` creates ADB with the resolved port and logs it |
| `src/driver.js` | accepts `adbPort` in `desiredCapConstraints`, forwards `appium:adbPort` to `getAdb()` |
| `scripts/{brave,opera,duckduckgo,samsung,edge}.js` | resolve the port for their own ADB instance and their UiAutomator2 session |

7 files, +42/−9. No behaviour change when the capability and the environment variable are absent: the resolver returns 5037, exactly as before.

## Testing

Builds clean and every touched file parses. **Not yet exercised against a real adb server on a non-default port** — that is the main thing this draft needs before it should merge, along with a decision on whether `CDP_ADB_PORT` is the preferred variable name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)